### PR TITLE
Incorrect prototype of eel_set_casts()

### DIFF
--- a/include/EEL.h
+++ b/include/EEL.h
@@ -137,7 +137,7 @@ EELAPI(const char *)eel_v2s(EEL_value *v);
  * SUCCESS:	Returns the new object.
  * FAILURE:	Returns NULL.
  */
-EELAPI(EEL_object *)eel_new_indexable(EEL_vm *vm, EEL_classes cid, int len);
+EELAPI(EEL_object *)eel_new_indexable(EEL_vm *vm, EEL_classes cid, int length);
 
 #ifdef __cplusplus
 };

--- a/include/EEL_register.h
+++ b/include/EEL_register.h
@@ -148,7 +148,7 @@ EELAPI(EEL_xno)eel_set_metamethod(EEL_object *c, EEL_mmindex mm, EEL_mm_cb cb);
  * SUCCESS: Returns 0.
  * FAILURE: Returns an EEL exception number.
  */
-EELAPI(EEL_xno)eel_set_casts(EEL_vm *vm, int from, int to, EEL_cast_cb cb);
+EELAPI(EEL_xno)eel_set_casts(EEL_vm *vm, EEL_classes from, EEL_classes to, EEL_cast_cb cb);
 
 /*
  * C callback for calls from the EEL VM. The callback should return 0 if all is

--- a/src/core/e_exceptions.c
+++ b/src/core/e_exceptions.c
@@ -183,7 +183,7 @@ static int already_registered(const EEL_xdef *xdefs, int min, int max,
 }
 
 
-int eel_x_register(EEL_vm *vm, const EEL_xdef *xdefs)
+int eel_x_register(EEL_vm *vm, const EEL_xdef *exceptions)
 {
 	EEL_xblock *xb;
 	EEL_xentry *xe;
@@ -193,10 +193,10 @@ int eel_x_register(EEL_vm *vm, const EEL_xdef *xdefs)
 	int max = 0x80000000;
 
 	/* Count and verify the entries */
-	while(xdefs[count].code || xdefs[count].name ||
-			xdefs[count].description)
+	while(exceptions[count].code || exceptions[count].name ||
+			exceptions[count].description)
 	{
-		const EEL_xdef *xd = &xdefs[count];
+		const EEL_xdef *xd = &exceptions[count];
 		if(!xd->name)
 		{
 			fprintf(stderr, "eel_x_register(): No name specified "
@@ -231,12 +231,12 @@ int eel_x_register(EEL_vm *vm, const EEL_xdef *xdefs)
 	{
 		fprintf(stderr, "eel_x_register(): Exception code range %d..%d"
 				" is too wide! (%s...)\n", min, max,
-				xdefs->name);
+				exceptions->name);
 		return -EEL_XWIDEXRANGE;
 	}
 
 	/* If an identical block is already registered, just return that! */
-	if((i = already_registered(xdefs, min, max, count)))
+	if((i = already_registered(exceptions, min, max, count)))
 		return e_x_registry[i]->base;
 
 	/* Create and fill in exception block! */
@@ -253,19 +253,19 @@ int eel_x_register(EEL_vm *vm, const EEL_xdef *xdefs)
 	}
 	for(i = 0; i < count; ++i)
 	{
-		int ei = xdefs[i].code - min;
-		if(xdefs[i].name)
+		int ei = exceptions[i].code - min;
+		if(exceptions[i].name)
 		{
-			xe[ei].name = strdup(xdefs[i].name);
+			xe[ei].name = strdup(exceptions[i].name);
 			if(!xe[ei].name)
 			{
 				destroy_xblock(xb);
 				return -EEL_XMEMORY;
 			}
 		}
-		if(xdefs[i].description)
+		if(exceptions[i].description)
 		{
-			xe[ei].description = strdup(xdefs[i].description);
+			xe[ei].description = strdup(exceptions[i].description);
 			if(!xe[ei].description)
 			{
 				destroy_xblock(xb);

--- a/src/core/e_object.c
+++ b/src/core/e_object.c
@@ -144,11 +144,11 @@ void eel_o__dealloc(EEL_object *o)
 
 
 /* Free object 'o' */
-void eel_o_free(EEL_object *o)
+void eel_o_free(EEL_object *object)
 {
 	EEL_vm *vm;
 #ifdef EEL_VM_CHECKING
-	if(!o)
+	if(!object)
 	{
 		fprintf(stderr, "INTERNAL ERROR: Someone tried to "
 				"eel_o_free() a NULL pointer!");
@@ -156,9 +156,9 @@ void eel_o_free(EEL_object *o)
 		return;
 	}
 #endif
-	vm = o->vm;
-	eel_o_disown_nz(VMP->state->classes[o->classid]);
-	o__dealloc(o);
+	vm = object->vm;
+	eel_o_disown_nz(VMP->state->classes[object->classid]);
+	o__dealloc(object);
 }
 
 

--- a/src/core/e_vm.c
+++ b/src/core/e_vm.c
@@ -2680,10 +2680,10 @@ static inline EEL_xno call_do_run(EEL_vm *vm)
 	}
 }
 
-EEL_xno eel_call(EEL_vm *vm, EEL_object *fo)
+EEL_xno eel_call(EEL_vm *vm, EEL_object *f)
 {
 	EEL_xno x;
-	EEL_function *f;
+	EEL_function *func;
 	int result;
 /*FIXME:*/
 	int save_resv = vm->resv;
@@ -2691,15 +2691,15 @@ EEL_xno eel_call(EEL_vm *vm, EEL_object *fo)
 	int save_argc = vm->argc;
 /*FIXME:*/
 	eel_clear_errors(VMP->state);
-	if(fo->classid != EEL_CFUNCTION)
+	if(f->classid != EEL_CFUNCTION)
 	{
-		call_msg(fo, EEL_EM_VMERROR, "  Object is not callable!");
+		call_msg(f, EEL_EM_VMERROR, "  Object is not callable!");
 		return EEL_XNEEDCALLABLE;
 	}
-	f = o2EEL_function(fo);
+	func = o2EEL_function(f);
 
-	DBG4C(printf("---------- eel_call(%s) ----------\n", eel_o2s(f->common.name));)
-	x = check_args(vm, fo);
+	DBG4C(printf("---------- eel_call(%s) ----------\n", eel_o2s(func->common.name));)
+	x = check_args(vm, f);
 	if(x)
 	{
 		const char *s;
@@ -2718,7 +2718,7 @@ EEL_xno eel_call(EEL_vm *vm, EEL_object *fo)
 			s = "  Incorrect arguments!";
 			break;
 		}
-		call_msg(fo, EEL_EM_VMERROR, s);
+		call_msg(f, EEL_EM_VMERROR, s);
 		reset_args(vm);
 /*FIXME:*/
 		vm->resv = save_resv;
@@ -2733,21 +2733,21 @@ EEL_xno eel_call(EEL_vm *vm, EEL_object *fo)
 		result = vm->base;
 	else
 		result = -1;
-	x = call_f(vm, fo, result, 0);
+	x = call_f(vm, f, result, 0);
 	if(!x)
 	{
 		/* If it's an EEL function, we actually need to *run* it...! */
-		if(!(f->common.flags & EEL_FF_CFUNC))
+		if(!(func->common.flags & EEL_FF_CFUNC))
 		{
 			x = call_do_run(vm);
 			if(x)
-				call_msg(fo, EEL_EM_VMERROR, "  Function "
+				call_msg(f, EEL_EM_VMERROR, "  Function "
 						"aborted with exception %s",
 						eel_x_name(vm, x));
 		}
 	}
 	else
-		call_msg(fo, EEL_EM_VMERROR, "  Exception %s was thrown.",
+		call_msg(f, EEL_EM_VMERROR, "  Exception %s was thrown.",
 				eel_x_name(vm, x));
 /*FIXME:*/
 	vm->resv = save_resv;


### PR DESCRIPTION
The prototype of eel_set_casts() in EEL_register.h is wrong, it does not match the implementation in e_cast.c:
`EEL_xno eel_set_casts(EEL_vm *vm, int from, int to, EEL_cast_cb cb);`
vs
`EEL_xno eel_set_casts(EEL_vm *vm, EEL_classes from, EEL_classes to, EEL_cast_cb cb);`

When I found this I thought it might be useful to do some more cleanup. I renamed a few variables so that they have identical variable names in the prototype and the implementation.

There are still some inconsistencies about how the variables are named between the functinos, eg some objects are named "o" while others are named "object". But that is to much work to fix and wouldn't really contribute to anything useful but to please my OCD. ^_^